### PR TITLE
[ Profile ] 팔로워 수 반영

### DIFF
--- a/src/component/Profile/Info/CurrentInfo.tsx
+++ b/src/component/Profile/Info/CurrentInfo.tsx
@@ -1,14 +1,18 @@
 import styled from 'styled-components';
 
-const FOLLOWER_INFO = [27, 2, 2];
+type Props = {
+  follower: number | undefined;
+};
 
-const CURRENT_INFO = [
-  { title: '게시물', info: FOLLOWER_INFO[0] },
-  { title: '팔로워', info: FOLLOWER_INFO[1] },
-  { title: '팔로우', info: FOLLOWER_INFO[2] },
-];
+const CurrentInfo = ({ follower }: Props) => {
+  const FOLLOWER_INFO = [27, follower, 2];
 
-const CurrentInfo = () => {
+  const CURRENT_INFO = [
+    { title: '게시물', info: FOLLOWER_INFO[0] },
+    { title: '팔로워', info: FOLLOWER_INFO[1] },
+    { title: '팔로우', info: FOLLOWER_INFO[2] },
+  ];
+
   return (
     <section>
       <CurrentInfoWrapper>

--- a/src/component/Profile/Info/CurrentInfo.tsx
+++ b/src/component/Profile/Info/CurrentInfo.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 
-const DUMMY_INFO = [27, 904, 701];
+const FOLLOWER_INFO = [27, 2, 2];
 
 const CURRENT_INFO = [
-  { title: '게시물', info: DUMMY_INFO[0] },
-  { title: '팔로워', info: DUMMY_INFO[1] },
-  { title: '팔로우', info: DUMMY_INFO[2] },
+  { title: '게시물', info: FOLLOWER_INFO[0] },
+  { title: '팔로워', info: FOLLOWER_INFO[1] },
+  { title: '팔로우', info: FOLLOWER_INFO[2] },
 ];
 
 const CurrentInfo = () => {

--- a/src/component/Profile/Info/CurrentInfo.tsx
+++ b/src/component/Profile/Info/CurrentInfo.tsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 
 type Props = {
-  follower: number | undefined;
+  followerStatus: Array<number>;
 };
 
-const CurrentInfo = ({ follower }: Props) => {
-  const FOLLOWER_INFO = [27, follower, 2];
+const CurrentInfo = ({ followerStatus }: Props) => {
+  const FOLLOWER_INFO = [27, followerStatus[0], followerStatus[1]];
 
   const CURRENT_INFO = [
     { title: '게시물', info: FOLLOWER_INFO[0] },

--- a/src/component/Profile/Profile.tsx
+++ b/src/component/Profile/Profile.tsx
@@ -6,8 +6,14 @@ type Props = {
   handleModal: () => void;
   isFollowed: boolean;
   handleClickFollowBtn: () => void;
+  follower: number | undefined;
 };
-const Profile = ({ handleModal, isFollowed, handleClickFollowBtn }: Props) => {
+const Profile = ({
+  handleModal,
+  isFollowed,
+  handleClickFollowBtn,
+  follower,
+}: Props) => {
   return (
     <ProfileLayout>
       <UserImg />
@@ -15,6 +21,7 @@ const Profile = ({ handleModal, isFollowed, handleClickFollowBtn }: Props) => {
         handleModal={handleModal}
         isFollowed={isFollowed}
         handleClickFollowBtn={handleClickFollowBtn}
+        follower={follower}
       />
     </ProfileLayout>
   );

--- a/src/component/Profile/Profile.tsx
+++ b/src/component/Profile/Profile.tsx
@@ -6,13 +6,13 @@ type Props = {
   handleModal: () => void;
   isFollowed: boolean;
   handleClickFollowBtn: () => void;
-  follower: number | undefined;
+  followerStatus: Array<number>;
 };
 const Profile = ({
   handleModal,
   isFollowed,
   handleClickFollowBtn,
-  follower,
+  followerStatus,
 }: Props) => {
   return (
     <ProfileLayout>
@@ -21,7 +21,7 @@ const Profile = ({
         handleModal={handleModal}
         isFollowed={isFollowed}
         handleClickFollowBtn={handleClickFollowBtn}
-        follower={follower}
+        followerStatus={followerStatus}
       />
     </ProfileLayout>
   );

--- a/src/component/Profile/UserInfo.tsx
+++ b/src/component/Profile/UserInfo.tsx
@@ -7,13 +7,13 @@ type Props = {
   handleModal: () => void;
   isFollowed: boolean;
   handleClickFollowBtn: () => void;
-  follower: number | undefined;
+  followerStatus: Array<number>;
 };
 const UserInfo = ({
   handleModal,
   isFollowed,
   handleClickFollowBtn,
-  follower,
+  followerStatus,
 }: Props) => {
   return (
     <UserInfoLayout>
@@ -22,7 +22,7 @@ const UserInfo = ({
         isFollowed={isFollowed}
         handleClickFollowBtn={handleClickFollowBtn}
       />
-      <CurrentInfo follower={follower}/>
+      <CurrentInfo followerStatus={followerStatus}/>
       <SubInfo />
     </UserInfoLayout>
   );

--- a/src/component/Profile/UserInfo.tsx
+++ b/src/component/Profile/UserInfo.tsx
@@ -7,8 +7,14 @@ type Props = {
   handleModal: () => void;
   isFollowed: boolean;
   handleClickFollowBtn: () => void;
+  follower: number | undefined;
 };
-const UserInfo = ({ handleModal, isFollowed, handleClickFollowBtn }: Props) => {
+const UserInfo = ({
+  handleModal,
+  isFollowed,
+  handleClickFollowBtn,
+  follower,
+}: Props) => {
   return (
     <UserInfoLayout>
       <MainInfo
@@ -16,7 +22,7 @@ const UserInfo = ({ handleModal, isFollowed, handleClickFollowBtn }: Props) => {
         isFollowed={isFollowed}
         handleClickFollowBtn={handleClickFollowBtn}
       />
-      <CurrentInfo />
+      <CurrentInfo follower={follower}/>
       <SubInfo />
     </UserInfoLayout>
   );

--- a/src/page/InstaAccount.tsx
+++ b/src/page/InstaAccount.tsx
@@ -9,7 +9,7 @@ import Posts from '../component/Posts/Posts';
 import Profile from '../component/Profile/Profile';
 import Recommend from '../component/Recommend/Recommend';
 
-type object1 = {
+type DataType = {
   followUser?: {
     followingCount?: number;
     followerCount?: number;
@@ -37,7 +37,7 @@ const InstaAccount = () => {
 
     commitFunction({
       variables: {},
-      onCompleted(data: object1) {
+      onCompleted(data: DataType) {
         if (data.followUser) {
           setFollower(data.followUser.followingCount);
         } else if (data.unfollowUser) {
@@ -68,7 +68,7 @@ const InstaAccount = () => {
         isFollowed={isFollowed}
         handleModal={handleModal}
         handleClickFollowBtn={handleClickFollowBtn}
-        follower = {follower}
+        follower={follower}
       />
       <Recommend />
       <Posts />

--- a/src/page/InstaAccount.tsx
+++ b/src/page/InstaAccount.tsx
@@ -39,12 +39,10 @@ const InstaAccount = () => {
       variables: {},
       onCompleted(data: DataType) {
         const { followUser, unfollowUser } = data;
+        const user = followUser || unfollowUser;
 
-        if (followUser) {
-          const { followingCount, followerCount } = followUser;
-          setFollowerStatus([followingCount, followerCount]);
-        } else if (unfollowUser) {
-          const { followingCount, followerCount } = unfollowUser;
+        if (user) {
+          const { followingCount, followerCount } = user;
           setFollowerStatus([followingCount, followerCount]);
         }
       },

--- a/src/page/InstaAccount.tsx
+++ b/src/page/InstaAccount.tsx
@@ -11,20 +11,20 @@ import Recommend from '../component/Recommend/Recommend';
 
 type DataType = {
   followUser?: {
-    followingCount?: number;
-    followerCount?: number;
+    followingCount: number;
+    followerCount: number;
   };
 
   unfollowUser?: {
-    followingCount?: number;
-    followerCount?: number;
+    followingCount: number;
+    followerCount: number;
   };
 };
 
 const InstaAccount = () => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [isFollowed, setIsFollowed] = useState(false);
-  const [follower, setFollower] = useState<number | undefined>(2);
+  const [followerStatus, setFollowerStatus] = useState<number[]>([2, 2]);
 
   const [commitUnfollow] = useMutation(unfollowUser);
   const [commitFollow] = useMutation(followUser);
@@ -38,10 +38,14 @@ const InstaAccount = () => {
     commitFunction({
       variables: {},
       onCompleted(data: DataType) {
-        if (data.followUser) {
-          setFollower(data.followUser.followingCount);
-        } else if (data.unfollowUser) {
-          setFollower(data.unfollowUser.followingCount);
+        const { followUser, unfollowUser } = data;
+
+        if (followUser) {
+          const { followingCount, followerCount } = followUser;
+          setFollowerStatus([followingCount, followerCount]);
+        } else if (unfollowUser) {
+          const { followingCount, followerCount } = unfollowUser;
+          setFollowerStatus([followingCount, followerCount]);
         }
       },
     });
@@ -68,7 +72,7 @@ const InstaAccount = () => {
         isFollowed={isFollowed}
         handleModal={handleModal}
         handleClickFollowBtn={handleClickFollowBtn}
-        follower={follower}
+        followerStatus={followerStatus}
       />
       <Recommend />
       <Posts />

--- a/src/page/InstaAccount.tsx
+++ b/src/page/InstaAccount.tsx
@@ -9,9 +9,23 @@ import Posts from '../component/Posts/Posts';
 import Profile from '../component/Profile/Profile';
 import Recommend from '../component/Recommend/Recommend';
 
+type object1 = {
+  followUser?: {
+    followingCount?: number;
+    followerCount?: number;
+  };
+
+  unfollowUser?: {
+    followingCount?: number;
+    followerCount?: number;
+  };
+};
+
 const InstaAccount = () => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [isFollowed, setIsFollowed] = useState(false);
+  const [follower, setFollower] = useState<number | undefined>(2);
+
   const [commitUnfollow] = useMutation(unfollowUser);
   const [commitFollow] = useMutation(followUser);
   const handleModal = () => {
@@ -23,8 +37,12 @@ const InstaAccount = () => {
 
     commitFunction({
       variables: {},
-      onCompleted(data) {
-        console.log(data);
+      onCompleted(data: object1) {
+        if (data.followUser) {
+          setFollower(data.followUser.followingCount);
+        } else if (data.unfollowUser) {
+          setFollower(data.unfollowUser.followingCount);
+        }
       },
     });
   };
@@ -50,6 +68,7 @@ const InstaAccount = () => {
         isFollowed={isFollowed}
         handleModal={handleModal}
         handleClickFollowBtn={handleClickFollowBtn}
+        follower = {follower}
       />
       <Recommend />
       <Posts />


### PR DESCRIPTION
<!-- PR 제목은 관련 이슈번호의 제목과 동일한 제목!! -->

<!-- 제목은 [ 페이지명 ] 내용 으로 작성합니다  -->
<!-- ex) [ Main ] 메인 뷰 구현 -->

## 🔥 Related Issues

- close #13 

## ✅ 작업 내용

- [x] 서버 통신 이후 변경된 팔로워 수 반영

## 📸 스크린샷 / GIF / Link

https://github.com/Graphql-Team1/team1-client/assets/80264647/031309f8-058f-4cd9-a5a5-ccd1364c1e27

## 📌 이슈 사항
### 1️⃣ 초기 팔로워 수
- GET을 하지 않아서 초기 팔로워 수를 받아오는 과정이 없기 때문에, 팔로우 버튼 누르기 전(팔로워 수 1명 증가 전) 숫자인 2로 초기화했습니다.

### 2️⃣ 팔로워 수 업데이트
- commitFunction의 onCompleted 안에서 변경된 팔로워 수를 반영해줬어요!
- 서버 통신 이후 받아온 데이터 followUser/ unfollowUser에 따라 수행될 함수를 분기처리했습니다 !

```typescript
  onCompleted(data: DataType) {
        const { followUser, unfollowUser } = data;

        if (followUser) {
          const { followingCount, followerCount } = followUser;
          setFollowerStatus([followingCount, followerCount]);
        } else if (unfollowUser) {
          const { followingCount, followerCount } = unfollowUser;
          setFollowerStatus([followingCount, followerCount]);
        }
      },
```

- 변경된 팔로워, 팔로우 정보를 배열로 정의해서 props로 내려주었고, 이 값으로 팔로워 정보 배열을 초기화해서 변경 사항이 바로 반영될 수 있게 구현했습니다 !

```typescript
 // Profile > Info > CurrentInfo.tsx 
  const FOLLOWER_INFO = [27, followerStatus[0], followerStatus[1]];

  const CURRENT_INFO = [
    { title: '게시물', info: FOLLOWER_INFO[0] },
    { title: '팔로워', info: FOLLOWER_INFO[1] },
    { title: '팔로우', info: FOLLOWER_INFO[2] },
  ];
```

## ✍ 궁금한 것
X